### PR TITLE
Fix the Join page interaction & styling to guide the user toward success

### DIFF
--- a/src/pages/Join/User/User.css
+++ b/src/pages/Join/User/User.css
@@ -45,4 +45,10 @@
 
 .join-class-btn {
   width: 100%;
+  transition: 0.2s all;
+}
+
+.join-class-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
 }

--- a/src/pages/Join/User/User.jsx
+++ b/src/pages/Join/User/User.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import * as userAvatars from '../../../assets/avatars/user-avatars';
@@ -12,6 +12,15 @@ const User = () => {
   const { user, updateUser } = useUser();
   const [name, setname] = useState(user.name);
   const [avatar, setAvatar] = useState(user.avatar);
+  const nameInputRef = useRef();
+
+  const handleAvatarClick = (avatarSrcName) => {
+    setAvatar(avatarSrcName);
+    // If the name has not been filled-in yet, give it focus so the user naturally understands that that is what is needed next
+    if (!name) {
+      nameInputRef.current?.focus();
+    }
+  };
 
   const joinClass = (e) => {
     e.preventDefault();
@@ -22,14 +31,22 @@ const User = () => {
     } else console.error('Error joining class');
   };
 
+  const isBtnDisabled = !(name && avatar);
+  // TODO: It would be nicer to be specific to the user about which one they lack, e.g., "Please enter a name"
+  const disabledBtnTooltip = "Please enter a name and select an avatar";
+  const enabledBtnTooltip = "Let's rock! 🏃🏽‍♀️";
+
   return (
     <section className="user-section">
       <h2>Join the class</h2>
       <form onSubmit={joinClass}>
         <input
+          ref={nameInputRef}
           type="text"
           id="name"
           placeholder="Your name"
+          // TODO: Discuss this idea and if we want to us it, determine how to suppress the compilation error ("jsx-a11y/no-autofocus")
+          //autoFocus   
           value={name}
           onChange={(e) => setname(e.target.value)}
         />
@@ -42,13 +59,19 @@ const User = () => {
                 hoverable
                 selected={avatar === avatarSrcName}
                 key={avatarSrcName}
-                onClick={() => setAvatar(avatarSrcName)}
+                onClick={() => handleAvatarClick(avatarSrcName)}
               />
             ))}
           </div>
         </div>
       </form>
-      <button type="submit" className="join-class-btn" onClick={joinClass}>
+      <button 
+        type="submit" 
+        className="join-class-btn" 
+        disabled={isBtnDisabled} 
+        title={isBtnDisabled ? disabledBtnTooltip : enabledBtnTooltip} 
+        onClick={joinClass}
+      >
         Join Class
       </button>
     </section>


### PR DESCRIPTION
# The problem

When I first visited this demo, I easily got into an error state that I could only diagnose by opening the dev tools and seeing an error in the console (there was no indication of the issue in the UI).

Here's what happened.  When I visited this demo, the `name` input did not catch my attention but the `avatar` items did.  So I clicked one of the avatars, saw that it was in a selected state, and proceeded to click the "Join Class" button (which was enabled, both literally and visually appeared as such).  To my surprise, nothing happened.   Again, I did not notice that I needed to fill-in a name.  And there was nothing guiding me toward doing so.

That's when I saw this in the dev tools:

<img width="1293" alt="image" src="https://user-images.githubusercontent.com/7502365/219766372-acf7068d-7197-4d73-9304-d2b7b9859918.png">

When I followed the error, I found that the button's click handler was being called and that the error was on this line:

<img width="1107" alt="image" src="https://user-images.githubusercontent.com/7502365/219766853-4a8437ad-e3d8-456d-bd8b-0635f49fa017.png">

# My solution

In general, I like to build experiences which attempt to prevent the user from getting into an error state, while doing so in a naturally-guiding manner.

So here's what I've applied that approach for this situation:
1. Disabled the "Join Class" button if either `name` or `avatar` have not been filled-in/selected
2. Added visual cues (styling) about the disabled button state
3. Added tooltips to the button to help the user understand why it is disabled
4. If the user first selects an avatar, and the `name` field has not-yet been filled-in, I give the name field **focus** so that the user naturally understands that they should fill that in next.
5. (pending discussion) I also thought it would be a good idea to give the `name` field focus immediately when the page loads to help deal with this issue.  However, when I tried adding the `autoFocus` prop, it caused a compilation error ("jsx-a11y/no-autofocus"), so for now I commented that out pending discussion about whether or not that would be a good idea.

Here's what the experience looks like now.

Right after clicking on an `avatar`, when there is no `name` filled-in yet:
<img width="571" alt="image" src="https://user-images.githubusercontent.com/7502365/219769458-ae01bd66-bd1b-44c9-bd13-517d3c9ebeb0.png">
Here we see that the `name` input is automatically given focus.  We also see that that the "Join Class" button is disabled and has a disabled visual state.  Not shown here is the tooltip on that button and the "not allowed" cursor that appears when hovering over the button.

Next, after typing a name:
<img width="561" alt="image" src="https://user-images.githubusercontent.com/7502365/219769903-c764226b-bd50-49b3-9e9e-c6b3b4a09b6c.png">
Now the user sees the button become enabled.

And they are encouraged to **rock on** 😆!
<img width="595" alt="image" src="https://user-images.githubusercontent.com/7502365/219770445-fa3626f5-6d0b-4829-b87d-1ec2273b71d9.png">

# Next steps

- [ ] Discuss the overall approach
- [ ] Discuss the `autoFocus` idea
- [ ] Potentially add more-specific tooltip text when the button is disabled (right now I have a general statement that explains why the button is disabled but it would be nicer to explain exactly what is lacking).

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
